### PR TITLE
Make micro and milliseconds more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # trtz
 Unix command line tool to convert timezones ⏱️
+
+Accepts ISO 8601 timestamps and converts them to the local time of the host computer.
+
+# Usage
+
+```bash
+
+```
+
+

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Accepts ISO 8601 timestamps and converts them to the local time of the host comp
 # Usage
 
 ```bash
-
+echo "2024-01-29T23:21:38Z" | trtz
 ```
 
 

--- a/src/date_parse.rs
+++ b/src/date_parse.rs
@@ -46,3 +46,17 @@ pub fn fix_timestamp_in_line(line: &str, date_regex: &Regex) -> String {
 
     fixed_line.to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    // Note this useful idiom: importing names from outer (for mod tests) scope.
+    use super::*;
+
+    #[test]
+    fn test_fix_timestamp() {
+        let date_regex = get_iso_date_regex();
+        let line = "2024-01-27T04:15:46.280000Z";
+        let fixed_line = fix_timestamp_in_line(line, &date_regex);
+        assert_eq!(fixed_line, "2024-01-26T20:15:46.280000Z");
+    }
+}

--- a/src/date_parse.rs
+++ b/src/date_parse.rs
@@ -1,0 +1,48 @@
+use chrono::{DateTime, Local, TimeZone, Utc};
+use regex::{Captures, Regex};
+
+pub fn parse_regex_match<T: std::str::FromStr>(caps: &Captures, key: &str) -> Option<T> {
+    let found_key = caps.name(key)?;
+    let parse_result = found_key.as_str().parse::<T>();
+
+    match parse_result {
+        Ok(output) => Some(output),
+        Err(_) => panic!("Type mismatch, couldn't convert found key to input type"),
+    }
+}
+
+pub fn get_iso_date_regex() -> Regex {
+    Regex::new(
+        r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?P<separator>[.:])(?P<post_sep>\d{2,6})"
+        ).expect("Regex malformed")
+}
+
+pub fn fix_timestamp_in_line(line: &str, date_regex: &Regex) -> String {
+    let fixed_line = date_regex.replace(line, |caps: &Captures| {
+        // These "unwraps" are ok because we wouldn't have entered this closure without a match
+        // If we have a match, we have the groups
+        // if unwrap panics, you typed a key name wrong
+        let utc_date = Utc
+            .with_ymd_and_hms(
+                parse_regex_match::<i32>(caps, "year").unwrap(),
+                parse_regex_match::<u32>(caps, "month").unwrap(),
+                parse_regex_match::<u32>(caps, "day").unwrap(),
+                parse_regex_match::<u32>(caps, "hour").unwrap(),
+                parse_regex_match::<u32>(caps, "minute").unwrap(),
+                parse_regex_match::<u32>(caps, "second").unwrap(),
+            )
+            .unwrap();
+
+        // Dealing with post separator a little differently, as we assume they aren't touched by timezone conversion
+        let post_sep = parse_regex_match::<u32>(caps, "post_sep").unwrap();
+        let separator = parse_regex_match::<String>(caps, "separator").unwrap();
+
+        let local_date: DateTime<Local> = DateTime::from(utc_date);
+        format!(
+            "{}{separator}{post_sep}",
+            local_date.format("%Y-%m-%dT%H:%M:%S")
+        )
+    });
+
+    fixed_line.to_string()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::io::{self, BufRead};
 
 mod date_parse;
 
-use crate::date_parse::{get_iso_date_regex, fix_timestamp_in_line};
+use crate::date_parse::{fix_timestamp_in_line, get_iso_date_regex};
 
 fn main() {
     let date_regex = get_iso_date_regex();

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn parse_regex_match<T: std::str::FromStr>(caps: &Captures, key: &str) -> Option
 
 fn main() {
     let date_regex = Regex::new(
-        r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?P<micro_separator>[.:])(?P<micro>\d{6})"
+        r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?P<micro_separator>[.:])(?P<micro>\d{2,6})"
         ).expect("Regex malformed");
 
     let stdin = io::stdin();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,48 +1,62 @@
-use std::io::{self, BufRead};
+use chrono::{DateTime, Local, TimeZone, Utc};
 use regex::{Captures, Regex};
-use chrono::{DateTime, TimeZone, Utc, Local};
-
+use std::io::{self, BufRead};
 
 fn parse_regex_match<T: std::str::FromStr>(caps: &Captures, key: &str) -> Option<T> {
     let found_key = caps.name(key)?;
-    let parse_result = found_key.as_str()
-                                .parse::<T>();
+    let parse_result = found_key.as_str().parse::<T>();
 
     match parse_result {
-        Ok(output) => return Some(output),
-        Err(_) => panic!("Type mismatch, couldn't convert found key to input type")
+        Ok(output) => Some(output),
+        Err(_) => panic!("Type mismatch, couldn't convert found key to input type"),
     }
 }
 
-fn main() {
-    let date_regex = Regex::new(
+fn get_iso_date_regex() -> Regex {
+    Regex::new(
         r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?P<separator>[.:])(?P<post_sep>\d{2,6})"
-        ).expect("Regex malformed");
+        ).expect("Regex malformed")
+}
+
+fn fix_timestamp_in_line(line: &str, date_regex: &Regex) -> String {
+    let fixed_line = date_regex.replace(line, |caps: &Captures| {
+        // These "unwraps" are ok because we wouldn't have entered this closure without a match
+        // If we have a match, we have the groups
+        // if unwrap panics, you typed a key name wrong
+        let utc_date = Utc
+            .with_ymd_and_hms(
+                parse_regex_match::<i32>(caps, "year").unwrap(),
+                parse_regex_match::<u32>(caps, "month").unwrap(),
+                parse_regex_match::<u32>(caps, "day").unwrap(),
+                parse_regex_match::<u32>(caps, "hour").unwrap(),
+                parse_regex_match::<u32>(caps, "minute").unwrap(),
+                parse_regex_match::<u32>(caps, "second").unwrap(),
+            )
+            .unwrap();
+
+        // Dealing with post separator a little differently, as we assume they aren't touched by timezone conversion
+        let post_sep = parse_regex_match::<u32>(caps, "post_sep").unwrap();
+        let separator = parse_regex_match::<String>(caps, "separator").unwrap();
+
+        let local_date: DateTime<Local> = DateTime::from(utc_date);
+        format!(
+            "{}{separator}{post_sep}",
+            local_date.format("%Y-%m-%dT%H:%M:%S")
+        )
+    });
+
+    fixed_line.to_string()
+}
+
+fn main() {
+    let date_regex = get_iso_date_regex();
 
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         let text = line.expect("Error reading line");
 
-        let fixed_line = date_regex.replace(&text, |caps: &Captures| {
-            // These "unwraps" are ok because we wouldn't have entered this closure without a match
-            // If we have a match, we have the groups
-            // if unwrap panics, you typed a key name wrong
-            let utc_date = Utc.with_ymd_and_hms(parse_regex_match::<i32>(&caps, "year").unwrap(),  
-                                                parse_regex_match::<u32>(&caps, "month").unwrap(), 
-                                                parse_regex_match::<u32>(&caps, "day").unwrap(), 
-                                                parse_regex_match::<u32>(&caps, "hour").unwrap(), 
-                                                parse_regex_match::<u32>(&caps, "minute").unwrap(), 
-                                                parse_regex_match::<u32>(&caps, "second").unwrap(), 
-                                               ).unwrap();
+        let fixed_line = fix_timestamp_in_line(&text, &date_regex);
 
-            // Dealing with post separator a little differently, as we assume they aren't touched by timezone conversion
-            let post_sep = parse_regex_match::<u32>(&caps, "post_sep").unwrap();
-            let separator = parse_regex_match::<String>(&caps, "separator").unwrap();
-
-            let local_date : DateTime<Local> = DateTime::from(utc_date);
-            format!("{}{separator}{post_sep}", local_date.format("%Y-%m-%dT%H:%M:%S"))
-        });
-
-        println!("{}", fixed_line.as_ref());
+        println!("{}", fixed_line);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,62 +1,16 @@
-use chrono::{DateTime, Local, TimeZone, Utc};
-use regex::{Captures, Regex};
 use std::io::{self, BufRead};
 
-fn parse_regex_match<T: std::str::FromStr>(caps: &Captures, key: &str) -> Option<T> {
-    let found_key = caps.name(key)?;
-    let parse_result = found_key.as_str().parse::<T>();
+mod date_parse;
 
-    match parse_result {
-        Ok(output) => Some(output),
-        Err(_) => panic!("Type mismatch, couldn't convert found key to input type"),
-    }
-}
-
-fn get_iso_date_regex() -> Regex {
-    Regex::new(
-        r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?P<separator>[.:])(?P<post_sep>\d{2,6})"
-        ).expect("Regex malformed")
-}
-
-fn fix_timestamp_in_line(line: &str, date_regex: &Regex) -> String {
-    let fixed_line = date_regex.replace(line, |caps: &Captures| {
-        // These "unwraps" are ok because we wouldn't have entered this closure without a match
-        // If we have a match, we have the groups
-        // if unwrap panics, you typed a key name wrong
-        let utc_date = Utc
-            .with_ymd_and_hms(
-                parse_regex_match::<i32>(caps, "year").unwrap(),
-                parse_regex_match::<u32>(caps, "month").unwrap(),
-                parse_regex_match::<u32>(caps, "day").unwrap(),
-                parse_regex_match::<u32>(caps, "hour").unwrap(),
-                parse_regex_match::<u32>(caps, "minute").unwrap(),
-                parse_regex_match::<u32>(caps, "second").unwrap(),
-            )
-            .unwrap();
-
-        // Dealing with post separator a little differently, as we assume they aren't touched by timezone conversion
-        let post_sep = parse_regex_match::<u32>(caps, "post_sep").unwrap();
-        let separator = parse_regex_match::<String>(caps, "separator").unwrap();
-
-        let local_date: DateTime<Local> = DateTime::from(utc_date);
-        format!(
-            "{}{separator}{post_sep}",
-            local_date.format("%Y-%m-%dT%H:%M:%S")
-        )
-    });
-
-    fixed_line.to_string()
-}
+use crate::date_parse::{get_iso_date_regex, fix_timestamp_in_line};
 
 fn main() {
     let date_regex = get_iso_date_regex();
 
-    let stdin = io::stdin();
-    for line in stdin.lock().lines() {
-        let text = line.expect("Error reading line");
-
-        let fixed_line = fix_timestamp_in_line(&text, &date_regex);
-
-        println!("{}", fixed_line);
-    }
+    io::stdin()
+        .lock()
+        .lines()
+        .map(|line| line.expect("Error reading line"))
+        .map(|line| fix_timestamp_in_line(&line, &date_regex))
+        .for_each(|line| println!("{}", line));
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn parse_regex_match<T: std::str::FromStr>(caps: &Captures, key: &str) -> Option
 
 fn main() {
     let date_regex = Regex::new(
-        r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?P<micro_separator>[.:])(?P<micro>\d{2,6})"
+        r"(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})T(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?P<separator>[.:])(?P<post_sep>\d{2,6})"
         ).expect("Regex malformed");
 
     let stdin = io::stdin();
@@ -35,12 +35,12 @@ fn main() {
                                                 parse_regex_match::<u32>(&caps, "second").unwrap(), 
                                                ).unwrap();
 
-            // Dealing with micros a little differently, as we assume they aren't touched by timezone conversion
-            let micros = parse_regex_match::<u32>(&caps, "micro").unwrap();
-            let micros_separator = parse_regex_match::<String>(&caps, "micro_separator").unwrap();
+            // Dealing with post separator a little differently, as we assume they aren't touched by timezone conversion
+            let post_sep = parse_regex_match::<u32>(&caps, "post_sep").unwrap();
+            let separator = parse_regex_match::<String>(&caps, "separator").unwrap();
 
             let local_date : DateTime<Local> = DateTime::from(utc_date);
-            format!("{}{micros_separator}{micros}", local_date.format("%Y-%m-%dT%H:%M:%S"))
+            format!("{}{separator}{post_sep}", local_date.format("%Y-%m-%dT%H:%M:%S"))
         });
 
         println!("{}", fixed_line.as_ref());


### PR DESCRIPTION
A few things chained together here:

1. Fix the ability to have a variable amount of time after the "separator" 

Supporting timestamps that look like `2024-01-29T23:21:38Z` as well as `2024-01-29T23:21:382343Z`

To do that, I needed to add unit tests, so:

2. Separate date parsing into new module
3. Write unit tests